### PR TITLE
Fixed title styling

### DIFF
--- a/frontend/src/app/core/header/header.component.css
+++ b/frontend/src/app/core/header/header.component.css
@@ -25,10 +25,10 @@
 
   font-family: 'Dancing Script', cursive;
 
-  position: absolute;
   text-align: center;
 
-  max-width: 80vw;
+  position: absolute;
+  width: 80vw;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -42,7 +42,15 @@
 }
 
 .header-regular-title-text {
+  position: relative;
   font-size: 4rem;
+}
+
+.header-regular-title-text-with-stroke {
+  position: absolute;
+  width: 100vw;
+  top: 0;
+  padding: 2rem;
 }
 
 @media only screen and (min-width: 768px) {
@@ -66,7 +74,7 @@
 
 .header-big-title-container::after {
   width: 100%;
-  height: 70vh;
+  height: 65vh;
   
   position: absolute;
   display: block;
@@ -91,7 +99,7 @@
   position: absolute;
   transform: translateX(-50%);
   left: 50%;
-  top: 53vh;
+  top: 48vh;
   
   z-index: 45;
   height: 23vh;
@@ -115,7 +123,7 @@
   }
 
   .header-logo {
-    top: 48vh;
+    top: 40vh;
     width: 30rem;
     height: auto;
   }

--- a/frontend/src/app/core/header/header.component.css
+++ b/frontend/src/app/core/header/header.component.css
@@ -7,8 +7,15 @@
 }
 
 /* keep normal cursor when hovering over title */
-.header-title-container:hover {
-  cursor: default;
+.header-title-text:hover {
+  cursor: pointer;
+}
+
+.header-title-text-with-stroke {
+    /* Supported by all browsers relevant for assignment, would like a better solution however */
+    -webkit-text-stroke: var(--title-border-color);
+    -webkit-text-stroke-width: 0.6rem;
+    paint-order: stroke fill;
 }
 
 .header-title-text {
@@ -16,22 +23,15 @@
 
   color: var(--title-center-color);
 
-  /* Supported by all browsers relevant for assignment, would like a better solution however */
-  -webkit-text-stroke: var(--title-border-color);
-  -webkit-text-stroke-width: 0.6rem;
-
-  paint-order: stroke fill;
-
   font-family: 'Dancing Script', cursive;
 
-  position: relative;
+  position: absolute;
   text-align: center;
 
   max-width: 80vw;
   left: 50%;
   transform: translateX(-50%);
 }
-
 
 /* ---------------------------------- */
 /*             REGULAR                */
@@ -46,9 +46,12 @@
 }
 
 @media only screen and (min-width: 768px) {
+  .header-title-text-with-stroke {
+    -webkit-text-stroke-width: 0.7rem;
+  }
+
   .header-regular-title-text {
     font-size: 8rem;
-    -webkit-text-stroke-width: 0.7rem;
   }
 }
 
@@ -58,7 +61,7 @@
 
 .header-big-title-container {
   background-color: var(--secondary-background-color);
-  margin-bottom: 50vh;
+  margin-bottom: 75vh;
 }
 
 .header-big-title-container::after {
@@ -80,8 +83,7 @@
 .header-big-title-text {
   z-index: 50;
   font-size: 6rem;
-  top: 10rem;
-  min-height: 30vh;
+  top: 10vh;
 }
 
 /* TODO: fix scaling for long mobile devices */
@@ -97,15 +99,18 @@
 
 @media only screen and (min-width: 768px) {
   .header-big-title-container {
-    margin-bottom: 50vh;
+    margin-bottom: 80vh;
   }
 
   .header-big-title-container::after {
     transform: skewY(4deg);
   }
 
-  .header-big-title-text {
+  .header-title-text-with-stroke {
     -webkit-text-stroke-width: 1rem;
+  }
+
+  .header-big-title-text {
     font-size: 9rem;
   }
 

--- a/frontend/src/app/core/header/header.component.html
+++ b/frontend/src/app/core/header/header.component.html
@@ -1,4 +1,5 @@
 <div [ngClass]="routeIsHomepage()?'header-big-title-container':'header-regular-title-container'" class="header-title-container" routerLink="/">
+  <h1 [ngClass]="routeIsHomepage()?'header-big-title-text':'header-regular-title-text'" class="header-title-text header-title-text-with-stroke">Get Caked!</h1>
   <h1 [ngClass]="routeIsHomepage()?'header-big-title-text':'header-regular-title-text'" class="header-title-text">Get Caked!</h1>
   <img *ngIf="routeIsHomepage()" class="header-logo" src="assets/img/cake.png">
 </div>

--- a/frontend/src/app/core/header/header.component.html
+++ b/frontend/src/app/core/header/header.component.html
@@ -1,6 +1,6 @@
 <div [ngClass]="routeIsHomepage()?'header-big-title-container':'header-regular-title-container'" class="header-title-container" routerLink="/">
   <h1 [ngClass]="routeIsHomepage()?'header-big-title-text':'header-regular-title-text'" class="header-title-text header-title-text-with-stroke">Get Caked!</h1>
-  <h1 [ngClass]="routeIsHomepage()?'header-big-title-text':'header-regular-title-text'" class="header-title-text">Get Caked!</h1>
+  <h1 [ngClass]="routeIsHomepage()?'header-big-title-text':'header-regular-title-text header-regular-title-text-with-stroke'" class="header-title-text">Get Caked!</h1>
   <img *ngIf="routeIsHomepage()" class="header-logo" src="assets/img/cake.png">
 </div>
 


### PR DESCRIPTION
- fixed cursor
- fixed outline in chromium

Ended up going with the (slightly hacky) solution of forcefully drawing a second non stroked title on top, because chromium hates using the ``paint-oder`` directive apparently.

Guess I just found one more reason to hate google, thus I'd say mission accomplished.

closes #9 